### PR TITLE
Fail silently on resolving variables, falling back to settings.TEMPLATE_STRING_IF_INVALID

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010, Trapeze
+Copyright (c) 2010-2012, Trapeze
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,9 @@ Hallo, Tobias!
 Testing
 -------
 
-With Django in your python path, run ``tests/run_tests.py``
+With Django in your python path, run ``tests/run_tests.py`` or use 
+`tox <http://tox.testrun.org/>`_ to run the tests using multiple
+Python and Django versions.
 
 Source
 ------
@@ -145,7 +147,7 @@ http://github.com/trapeze/fancy_tag
 License
 -------
 
-fancy_tag is Copyright (c) 2010 Sam Bull, Trapeze. It is free software, and
+fancy_tag is Copyright (c) 2010-2012 Sam Bull, Trapeze. It is free software, and
 may be redistributed under the terms specified in the LICENSE file.
 
 Credits

--- a/RELEASES
+++ b/RELEASES
@@ -1,3 +1,15 @@
+0.2.0
+=====
+
+Unreleased
+
+* Verified that fancy_tag works when using Django 1.4
+* Missing variable lookup now falls back to
+  settings.TEMPLATE_STRING_IF_INVALID instead of
+  raising VariableDoesNotExist
+
+* * *
+
 0.1.5
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ f.close()
 
 setup(
     name='fancy_tag',
-    version='0.1.5',
-    description="A replacement for Django's simple_tag decorator.",
+    version='0.2.0',
+    description="A powerful replacement for Django's simple_tag decorator that adds supports for positional, keyword arguments and template variable assignment.",
     long_description=readme,
     author='Sam Bull',
     author_email='sam@pocketuniverse.ca',

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -19,6 +19,10 @@ class FancyTagTestCase(TestCase):
         template = Template('{% load example_tags %}{% say_soup "Tomato" size="large" %}')
         self.assertEqual(template.render(Context()), 'Tomato Soup (large)')
 
+    def testContextLookupFailsSilently(self):
+        template = Template('{% load example_tags %}{% say_soup soup %}')
+        self.assertEqual(template.render(Context()), ' Soup')
+
     def testArgAfterKwargFails(self):
         self.assertRaises(
                 TemplateSyntaxError,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,15 @@
 # Haystack settings for running tests.
-DATABASE_ENGINE = 'sqlite3'
+DATABASE_ENGINE = 'django.db.backends.sqlite3'
 DATABASE_NAME = 'fancy_tag_test.db'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'fancy_tag_test.db'
+    }
+}
+
+SECRET_KEY = 'mAtTzVPOV9JY4eJQfqgW8eAS9DWKnt3MkvvpQI2MzkhAz7z3'
 
 INSTALLED_APPS = [
     'fancy_tag',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,35 @@
+[tox]
+envlist    = py25-1.2, py25-1.3,
+             py26-1.2, py26-1.3, py26-1.4,
+             py27-1.3, py27-1.4
+
+[testenv]
+commands   = python tests/run_tests.py
+
+[testenv:py25-1.2]
+basepython = python2.5
+deps       = django>=1.2,<1.3
+
+[testenv:py25-1.3]
+basepython = python2.5
+deps       = django>=1.3,<1.4
+
+[testenv:py26-1.2]
+basepython = python2.6
+deps       = django>=1.2,<1.3
+
+[testenv:py26-1.3]
+basepython = python2.6
+deps       = django>=1.3,<1.4
+
+[testenv:py26-1.4]
+basepython = python2.6
+deps       = django>=1.4,<1.5
+
+[testenv:py27-1.3]
+basepython = python2.7
+deps       = django>=1.3,<1.4
+
+[testenv:py27-1.4]
+basepython = python2.7
+deps       = django>=1.4,<1.5


### PR DESCRIPTION
Currently fancy_tag raises really hard to debug VariableDoesNotExist exceptions when looking up variables that are not available in the context.

Falling back to settings.TEMPLATE_STRING_IF_INVALID is much more user friendly. This requires tag authors to check their input values, but at least VariableDoesNotExist are now recoverable (by modifying the template tags).

Added tox to run the tests on multiple Python/Django versions at once, and changed the test settings so Django 1.4 can also be tested.

Updated some text files to note the changes made in this pull request, and updated the copyright year.

Changed the version number to 0.2.0 to signify serious change in behavior. Although I don't think anybody is relying on VariableDoesNotExist being raised.

Hope you can pull this (and release it). It's been an issue that has been mystifying some of the developers over here for a long time :).
